### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   prepare-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
       new_tag: ${{ steps.bump.outputs.new_tag }}


### PR DESCRIPTION
Potential fix for [https://github.com/matanbaruch/netbird-api-exporter/security/code-scanning/3](https://github.com/matanbaruch/netbird-api-exporter/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `prepare-version` job. Since this job only reads version information and does not perform any write operations, we will set the permissions to `contents: read`. This ensures that the job has the minimal permissions required to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
