### PR TITLE
Add Docker Compose test job to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,8 +151,12 @@ jobs:
         echo "| Docker Compose Test | ${{ needs.docker-compose-test.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        if [[ "${{ needs.unit-tests.result }}" != "success" ]]; then
-          echo "❌ Tests failed! Check the individual job logs for details." >> $GITHUB_STEP_SUMMARY
+        if [[ "${{ needs.unit-tests.result }}" != "success" ]] || \
+           [[ "${{ needs.integration-tests.result }}" != "success" && "${{ needs.integration-tests.result }}" != "skipped" ]] || \
+           [[ "${{ needs.performance-tests.result }}" != "success" ]] || \
+           [[ "${{ needs.benchmark-tests.result }}" != "success" ]] || \
+           [[ "${{ needs.docker-compose-test.result }}" != "success" ]]; then
+          echo "❌ Some tests failed! Check the individual job logs for details." >> $GITHUB_STEP_SUMMARY
           exit 1
         else
           echo "✅ All critical tests passed!" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request adds a new `docker-compose-test` job to the GitHub Actions workflow to ensure proper testing of services using Docker Compose. It also updates the test summary to include the results of this new job.

Updates to GitHub Actions workflow:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R116-R138): Added a new `docker-compose-test` job to run Docker Compose-based tests, including steps to start services, wait for readiness, and check the metrics endpoint.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R151): Updated the `test-summary` job to include the results of the new `docker-compose-test` in the test summary report.