### PR TITLE
Update import paths to reflect new GitHub repository structure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -273,7 +273,7 @@ package exporters
 
 import (
     "github.com/prometheus/client_golang/prometheus"
-    "netbird-api-exporter/pkg/netbird"
+    "github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 type PoliciesExporter struct {

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/exporters"
-	"netbird-api-exporter/pkg/utils"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/exporters"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/utils"
 )
 
 // debugLoggingMiddleware logs HTTP requests when debug level is enabled

--- a/pkg/exporters/dns.go
+++ b/pkg/exporters/dns.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 // DNSExporter handles DNS-specific metrics collection

--- a/pkg/exporters/dns_test.go
+++ b/pkg/exporters/dns_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestNewDNSExporter(t *testing.T) {

--- a/pkg/exporters/exporter.go
+++ b/pkg/exporters/exporter.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 // NetBirdExporter represents the main Prometheus exporter for NetBird APIs

--- a/pkg/exporters/exporter_test.go
+++ b/pkg/exporters/exporter_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestNewNetBirdExporter(t *testing.T) {

--- a/pkg/exporters/groups.go
+++ b/pkg/exporters/groups.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 // GroupsExporter handles groups-specific metrics collection

--- a/pkg/exporters/groups_test.go
+++ b/pkg/exporters/groups_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestNewGroupsExporter(t *testing.T) {

--- a/pkg/exporters/networks.go
+++ b/pkg/exporters/networks.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 // NetworksExporter handles networks-specific metrics collection

--- a/pkg/exporters/networks_test.go
+++ b/pkg/exporters/networks_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestNewNetworksExporter(t *testing.T) {

--- a/pkg/exporters/peers.go
+++ b/pkg/exporters/peers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 // PeersExporter handles peers-specific metrics collection

--- a/pkg/exporters/peers_test.go
+++ b/pkg/exporters/peers_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestNewPeersExporter(t *testing.T) {

--- a/pkg/exporters/performance_test.go
+++ b/pkg/exporters/performance_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestExporters_Performance_ConcurrentCollections(t *testing.T) {

--- a/pkg/exporters/users.go
+++ b/pkg/exporters/users.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 // UsersExporter handles users-specific metrics collection

--- a/pkg/exporters/users_test.go
+++ b/pkg/exporters/users_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
 )
 
 func TestNewUsersExporter(t *testing.T) {

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"netbird-api-exporter/pkg/exporters"
-	"netbird-api-exporter/pkg/netbird"
-	"netbird-api-exporter/pkg/utils"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/exporters"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/netbird"
+	"github.com/matanbaruch/netbird-api-exporter/pkg/utils"
 )
 
 // Integration tests that require a real NetBird API token


### PR DESCRIPTION
This pull request updates all import paths in the project to use a new package namespace, `github.com/matanbaruch/netbird-api-exporter`, instead of the old `netbird-api-exporter` namespace. The changes ensure consistency across the codebase and align with the updated repository structure.

### Namespace Update in Import Paths:

* Updated import paths in `ARCHITECTURE.md` to reflect the new package namespace.
* Updated import paths in `main.go` for `exporters` and `utils` packages.
* Updated import paths in various exporter files (`dns.go`, `groups.go`, `networks.go`, `peers.go`, `users.go`, and `exporter.go`) to use the new namespace. [[1]](diffhunk://#diff-6168cf8756a325b3a89260ae6f63cadc53b8ab3d98f2b7e20a6574d83b7b522cL12-R12) [[2]](diffhunk://#diff-21fbe9a5cc1814f88af6e84e17636ffb8c1a7e555077f8471105fa59be388fa4L11-R11) [[3]](diffhunk://#diff-a4ceeb571e8a6b4954f06ad8371f99fb0f54cd12b0f2537c600c6db18e42f766L11-R11) [[4]](diffhunk://#diff-ed739caf272531b8d58b9d163d0b6c485119e7e8eb6f76f958b9218e1fd963caL12-R12) [[5]](diffhunk://#diff-1d28e647eb86e3d059b38fe03fea6e7f693a95381e41d7cce34ef58986fc6f36L11-R11) [[6]](diffhunk://#diff-7bb24b9fa955a59147354aa1ad4544da0619769d029ccfb5b5a8ecc1dfac6bc0L9-R9)
* Updated import paths in corresponding test files for exporters (`dns_test.go`, `groups_test.go`, `networks_test.go`, `peers_test.go`, `users_test.go`, and `exporter_test.go`). [[1]](diffhunk://#diff-7e371f47788ef18d5b9789e19e8c6da6b9ae35ccf088db00f611e31e84d59b53L12-R12) [[2]](diffhunk://#diff-6b178b816db3cbbf9c25e5dc07465d4b18ac434fe0e845349368b855cea606beL12-R12) [[3]](diffhunk://#diff-ffd974b8fd47d58c74f29e906d29d51db1dfaea00d07c27d0ca40b2de112c0f2L12-R12) [[4]](diffhunk://#diff-8987816ecb5d48cfcbcd3c72b6fe26a0d1973975ec868138ea9f245cee762d8cL13-R13) [[5]](diffhunk://#diff-56dfc56a8b3af921e96d68e3b0df4d4067dee19b6b2449f576a0a816562f2ef8L13-R13) [[6]](diffhunk://#diff-8c5c9b5fe1ff236fc22ac2b0ecfd16023709903c732b7d0ec2ed07693315f9bcL12-R12)
* Updated import paths in `integration_test.go` to reflect the new namespace for `exporters`, `netbird`, and `utils`.