### PR TITLE
feat(metrics): add user_id label to peer metrics for enhanced tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Features
+- Add user_id label to peer metrics
+Files modified in this change:
+- Modified: README.md
+- Modified: pkg/exporters/peers.go
+- Modified: pkg/exporters/peers_test.go
+
 ## [0.1.56] - 2025-09-10
 
 ## [0.1.55] - 2025-09-09

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The exporter provides the following metrics:
 | ---------------------------------------- | ----- | ---------------------------------------------------------------------------- | ----------------------------------- |
 | `netbird_peers`                          | Gauge | Total number of NetBird peers                                                | -                                   |
 | `netbird_peers_connected`                | Gauge | Number of connected/disconnected peers                                       | `connected`                         |
-| `netbird_peer_last_seen_timestamp`       | Gauge | Last seen timestamp for each peer                                            | `peer_id`, `peer_name`, `hostname`  |
+| `netbird_peer_last_seen_timestamp`       | Gauge | Last seen timestamp for each peer                                            | `peer_id`, `peer_name`, `hostname`, `user_id`  |
 | `netbird_peers_by_os`                    | Gauge | Number of peers by operating system                                          | `os`                                |
 | `netbird_peers_by_country`               | Gauge | Number of peers by country/city                                              | `country_code`, `city_name`         |
 | `netbird_peers_by_group`                 | Gauge | Number of peers by group                                                     | `group_id`, `group_name`            |
@@ -49,7 +49,7 @@ The exporter provides the following metrics:
 | `netbird_peers_login_expired`            | Gauge | Number of peers with expired/valid login                                     | `login_expired`                     |
 | `netbird_peers_approval_required`        | Gauge | Number of peers requiring/not requiring approval                             | `approval_required`                 |
 | `netbird_peer_accessible_peers_count`    | Gauge | Number of accessible peers for each peer                                     | `peer_id`, `peer_name`              |
-| `netbird_peer_connection_status_by_name` | Gauge | Connection status of each peer by name (1 for connected, 0 for disconnected) | `peer_name`, `peer_id`, `connected` |
+| `netbird_peer_connection_status_by_name` | Gauge | Connection status of each peer by name (1 for connected, 0 for disconnected) | `peer_name`, `peer_id`, `connected`, `user_id` |
 
 ### Group Metrics Table
 

--- a/charts/netbird-api-exporter/Chart.yaml
+++ b/charts/netbird-api-exporter/Chart.yaml
@@ -57,6 +57,8 @@ annotations:
     - title: NetBird API Exporter Dashboard
       url: https://github.com/user-attachments/assets/df57ed5f-524a-4965-9b8a-a8cb97ee4892
   artifacthub.io/changes: |
+    - kind: added
+      description: "Add user_id label to peer metrics"
     - kind: fixed
       description: "Fix GitHub Actions workflow syntax errors in external PR handling"
     - kind: added

--- a/pkg/exporters/peers.go
+++ b/pkg/exporters/peers.go
@@ -56,7 +56,7 @@ func NewPeersExporter(client *nbclient.Client) *PeersExporter {
 				Name: "netbird_peer_last_seen_timestamp",
 				Help: "Last seen timestamp of NetBird peers",
 			},
-			[]string{"peer_id", "peer_name", "hostname"},
+			[]string{"peer_id", "peer_name", "hostname", "user_id"},
 		),
 
 		peersByOS: prometheus.NewGaugeVec(
@@ -120,7 +120,7 @@ func NewPeersExporter(client *nbclient.Client) *PeersExporter {
 				Name: "netbird_peer_connection_status_by_name",
 				Help: "Connection status of each peer by name (1 for connected, 0 for disconnected)",
 			},
-			[]string{"peer_name", "peer_id", "connected"},
+			[]string{"peer_name", "peer_id", "connected", "user_id"},
 		),
 	}
 }
@@ -207,7 +207,7 @@ func (e *PeersExporter) updateMetrics(peers []api.Peer) {
 		}
 
 		// Last seen timestamp
-		e.peersLastSeen.WithLabelValues(peer.Id, peer.Name, peer.Hostname).Set(float64(peer.LastSeen.Unix()))
+		e.peersLastSeen.WithLabelValues(peer.Id, peer.Name, peer.Hostname, peer.UserId).Set(float64(peer.LastSeen.Unix()))
 
 		// OS distribution
 		osKey := peer.Os
@@ -257,7 +257,7 @@ func (e *PeersExporter) updateMetrics(peers []api.Peer) {
 			connectedStr = "true"
 			connectionValue = 1.0
 		}
-		e.peerConnectionStatusByName.WithLabelValues(peer.Name, peer.Id, connectedStr).Set(connectionValue)
+		e.peerConnectionStatusByName.WithLabelValues(peer.Name, peer.Id, connectedStr, peer.UserId).Set(connectionValue)
 	}
 
 	// Set metrics

--- a/pkg/exporters/peers_test.go
+++ b/pkg/exporters/peers_test.go
@@ -113,6 +113,7 @@ func TestPeersExporter_Collect_Success(t *testing.T) {
 				ApprovalRequired: false,
 				CountryCode:      "US",
 				CityName:         "New York",
+				UserId:           "user1",
 			},
 			{
 				Id:               "peer2",
@@ -128,6 +129,7 @@ func TestPeersExporter_Collect_Success(t *testing.T) {
 				ApprovalRequired: true,
 				CountryCode:      "CA",
 				CityName:         "Toronto",
+				UserId:           "user2",
 			},
 		}
 
@@ -323,6 +325,7 @@ func TestPeersExporter_UpdateMetrics(t *testing.T) {
 			ApprovalRequired: false,
 			CountryCode:      "US",
 			CityName:         "New York",
+			UserId:           "user1",
 		},
 		{
 			Id:               "peer2",
@@ -335,6 +338,7 @@ func TestPeersExporter_UpdateMetrics(t *testing.T) {
 			ApprovalRequired: true,
 			CountryCode:      "US",
 			CityName:         "Los Angeles",
+			UserId:           "user2",
 		},
 	}
 
@@ -381,6 +385,7 @@ func TestPeersExporter_MetricLabels(t *testing.T) {
 			CountryCode: "US",
 			CityName:    "New York",
 			Groups:      []api.GroupMinimum{{Id: "group1", Name: "test-group"}},
+			UserId:      "user1",
 		},
 	}
 
@@ -424,11 +429,13 @@ func TestPeersExporter_ConnectionStatusByName(t *testing.T) {
 			Id:        "peer1",
 			Name:      "connected-peer",
 			Connected: true,
+			UserId:    "user1",
 		},
 		{
 			Id:        "peer2",
 			Name:      "disconnected-peer",
 			Connected: false,
+			UserId:    "user2",
 		},
 	}
 


### PR DESCRIPTION
### Description

This PR adds the `user_id` label to peer-related Prometheus metrics, enabling better user-level tracking and filtering of peer data.

The `user_id` label is now included in the following metrics:
- netbird_peer_last_seen_timestamp
- netbird_peer_connection_status_by_name

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] I have added an entry to the [CHANGELOG.md](https://github.com/netbirdio/netbird-api-exporter/blob/main/CHANGELOG.md) (if applicable).
